### PR TITLE
Change deep requiring of uuid/v4 - deprecated as of uuid@7.x

### DIFF
--- a/src/__mocks__/uuid.js
+++ b/src/__mocks__/uuid.js
@@ -1,0 +1,3 @@
+const v4 = jest.fn().mockImplementation(() => 'mocked-uuid');
+
+export { v4 };

--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -1,15 +1,15 @@
 import { when } from 'jest-when';
 import request from 'supertest';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import app from '../app';
 import config from '../config';
 import sendEhrRequest from '../services/ehr-request';
+import { getHealthCheck } from '../services/get-health-check';
+import { sendMessage } from '../services/mhs/mhs-outbound-client';
+import { parsePdsResponse } from '../services/pds/pds-response-handler';
+import { validatePdsResponse } from '../services/pds/pds-response-validator';
 import generatePdsRetrievalQuery from '../templates/generate-pds-retrieval-request';
 import generateUpdateOdsRequest from '../templates/generate-update-ods-request';
-import { getHealthCheck } from '../services/get-health-check';
-import { validatePdsResponse } from '../services/pds/pds-response-validator';
-import { parsePdsResponse } from '../services/pds/pds-response-handler';
-import { sendMessage } from '../services/mhs/mhs-outbound-client';
 
 jest.mock('../services/ehr-request');
 jest.mock('../config/logging');
@@ -20,7 +20,6 @@ jest.mock('../services/pds/pds-response-handler');
 jest.mock('../services/mhs/mhs-outbound-client');
 jest.mock('../templates/generate-pds-retrieval-request');
 jest.mock('../templates/generate-update-ods-request');
-jest.mock('uuid/v4');
 
 const testSerialChangeNumber = '2';
 const testPatientPdsId = 'cppz';

--- a/src/api/__tests__/pds-retrieval.test.js
+++ b/src/api/__tests__/pds-retrieval.test.js
@@ -1,13 +1,13 @@
 import { when } from 'jest-when';
 import request from 'supertest';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import { updateLogEvent, updateLogEventWithError } from '../../../src/middleware/logging';
 import app from '../../app';
 import config from '../../config';
 import { sendMessage } from '../../services/mhs/mhs-outbound-client';
-import generatePdsRetrievalQuery from '../../templates/generate-pds-retrieval-request';
-import { validatePdsResponse } from '../../services/pds/pds-response-validator';
 import { parsePdsResponse } from '../../services/pds/pds-response-handler';
+import { validatePdsResponse } from '../../services/pds/pds-response-validator';
+import generatePdsRetrievalQuery from '../../templates/generate-pds-retrieval-request';
 
 const mockUUID = 'ebf6ee70-b9b7-44a6-8780-a386fccd759c';
 const mockNoDataUUID = 'fdb5c732-9e82-48ef-991b-8cd54b485748';
@@ -51,7 +51,6 @@ jest.mock('../../middleware/logging');
 jest.mock('../../middleware/auth');
 jest.mock('../../services/mhs/mhs-outbound-client');
 jest.mock('../../templates/generate-pds-retrieval-request');
-jest.mock('uuid/v4');
 
 function generateLogEvent(message) {
   return {

--- a/src/api/__tests__/pds-update.test.js
+++ b/src/api/__tests__/pds-update.test.js
@@ -1,18 +1,17 @@
 import { when } from 'jest-when';
 import request from 'supertest';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import app from '../../app';
 import config from '../../config';
-import generateUpdateOdsRequest from '../../templates/generate-update-ods-request';
 import { updateLogEvent } from '../../middleware/logging';
 import { sendMessage } from '../../services/mhs/mhs-outbound-client';
+import generateUpdateOdsRequest from '../../templates/generate-update-ods-request';
 
 jest.mock('../../config/logging');
 jest.mock('../../middleware/logging');
 jest.mock('../../middleware/auth');
 jest.mock('../../services/mhs/mhs-outbound-client');
 jest.mock('../../templates/generate-update-ods-request');
-jest.mock('uuid/v4');
 
 const fakerequest =
   '<PRPA_IN000203UK03 xmlns="urn:hl7-org:v3" xmlns:hl7="urn:hl7-org:v3"></PRPA_IN000203UK03>';

--- a/src/api/pds-retrieval.js
+++ b/src/api/pds-retrieval.js
@@ -1,15 +1,15 @@
 import dateFormat from 'dateformat';
 import express from 'express';
 import { param } from 'express-validator';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import config from '../config';
 import { authenticateRequest } from '../middleware/auth';
 import { updateLogEvent, updateLogEventWithError } from '../middleware/logging';
 import { validate } from '../middleware/validation';
 import { sendMessage } from '../services/mhs/mhs-outbound-client';
-import generatePdsRetrievalQuery from '../templates/generate-pds-retrieval-request';
-import { validatePdsResponse } from '../services/pds/pds-response-validator';
 import { parsePdsResponse } from '../services/pds/pds-response-handler';
+import { validatePdsResponse } from '../services/pds/pds-response-validator';
+import generatePdsRetrievalQuery from '../templates/generate-pds-retrieval-request';
 
 const router = express.Router();
 

--- a/src/api/pds-update.js
+++ b/src/api/pds-update.js
@@ -1,13 +1,13 @@
-import express from 'express';
-import { param, body } from 'express-validator';
 import dateFormat from 'dateformat';
-import uuid from 'uuid/v4';
+import express from 'express';
+import { body, param } from 'express-validator';
+import { v4 as uuid } from 'uuid';
 import config from '../config';
-import generateUpdateOdsRequest from '../templates/generate-update-ods-request';
 import { authenticateRequest } from '../middleware/auth';
 import { updateLogEvent, updateLogEventWithError } from '../middleware/logging';
 import { validate } from '../middleware/validation';
 import { sendMessage } from '../services/mhs/mhs-outbound-client';
+import generateUpdateOdsRequest from '../templates/generate-update-ods-request';
 
 const router = express.Router();
 

--- a/src/middleware/__tests__/correlation.test.js
+++ b/src/middleware/__tests__/correlation.test.js
@@ -1,8 +1,15 @@
 import httpContext from 'async-local-storage';
 import axios from 'axios';
+import { v4 as uuid } from 'uuid';
 import { getCorrelationId, middleware } from '../correlation';
-
 httpContext.enable();
+
+uuid.mockImplementation(
+  jest
+    .fn(() => 'default-mocked-uuid')
+    .mockImplementationOnce(() => 'mocked-uuid')
+    .mockImplementationOnce(() => 'second-mocked-uuid')
+);
 
 describe('correlation middleware', () => {
   it('should set a different correlation id for each request', () => {

--- a/src/middleware/correlation.js
+++ b/src/middleware/correlation.js
@@ -1,6 +1,6 @@
 import httpContext from 'async-local-storage';
-import uuid from 'uuid/v4';
 import axios from 'axios';
+import { v4 as uuid } from 'uuid';
 
 const CORRELATION_ID_HEADER = 'X-Correlation-ID';
 const CORRELATION_ID_KEY = 'correlationId';

--- a/src/services/__tests__/consumer.test.js
+++ b/src/services/__tests__/consumer.test.js
@@ -1,13 +1,12 @@
-import { ConnectFailover, connect } from 'stompit';
-import initialiseConsumer from '../consumer';
-import config from '../../config';
-import handleMessage from '../message-handler';
-import logger from '../../config/logging';
 import httpContext from 'async-local-storage';
+import { connect, ConnectFailover } from 'stompit';
+import config from '../../config';
+import logger from '../../config/logging';
+import initialiseConsumer from '../consumer';
+import handleMessage from '../message-handler';
 
 httpContext.enable();
 
-jest.mock('uuid/v4', () => () => 'some-correlation-id');
 jest.mock('../../config/logging');
 jest.mock('../message-handler');
 

--- a/src/services/__tests__/ehr-request.test.js
+++ b/src/services/__tests__/ehr-request.test.js
@@ -8,7 +8,6 @@ import * as mhsQueueTestHelper from '../mhs/mhs-old-queue-test-helper';
 
 jest.mock('../mhs/mhs-old-queue-test-helper');
 jest.mock('../../middleware/logging');
-jest.mock('uuid/v4', () => () => 'some-uuid');
 
 describe('sendEhrRequest', () => {
   let ehrRequestQuery;
@@ -18,7 +17,7 @@ describe('sendEhrRequest', () => {
     config.deductionsOdsCode = 'some-ods-code';
 
     ehrRequestQuery = generateEhrRequestQuery({
-      id: 'some-uuid',
+      id: 'mocked-uuid',
       timestamp: '20190228112548',
       receivingService: {
         asid: receivingAsid,

--- a/src/services/__tests__/message-handler.test.js
+++ b/src/services/__tests__/message-handler.test.js
@@ -6,7 +6,6 @@ import handleMessage from '../message-handler';
 import * as mhsGatewayFake from '../mhs/mhs-old-queue-test-helper';
 
 jest.mock('../mhs/mhs-old-queue-test-helper');
-jest.mock('uuid/v4', () => () => 'some-uuid');
 jest.mock('../../middleware/logging');
 jest.mock('../ehr-repo-gateway');
 
@@ -79,7 +78,7 @@ describe('handleMessage', () => {
   it('should send generated continue request to fake MHS if message is EHR Request Completed and environment is not PTL', () => {
     return handleMessage(ehrRequestCompletedMessage).then(() => {
       const continueMessage = generateContinueRequest(
-        'some-uuid',
+        'mocked-uuid',
         '20190228112548',
         foundationSupplierAsid,
         config.deductionsAsid,

--- a/src/services/ehr-request.js
+++ b/src/services/ehr-request.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import config from '../config';
 import { updateLogEvent, updateLogEventWithError } from '../middleware/logging';
 import generateEhrRequestQuery from '../templates/ehr-request-template';

--- a/src/services/message-handler.js
+++ b/src/services/message-handler.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import config from '../config';
 import { updateLogEvent, updateLogEventWithError } from '../middleware/logging';
 import { generateContinueRequest } from '../templates/continue-template';

--- a/src/services/mhs/__tests__/mhs-outbound-client.test.js
+++ b/src/services/mhs/__tests__/mhs-outbound-client.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import dateFormat from 'dateformat';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import config from '../../../config';
 import { updateLogEventWithError } from '../../../middleware/logging';
 import generatePdsRetrievalQuery from '../../../templates/generate-pds-retrieval-request';

--- a/src/services/mhs/mhs-queue-test-queue-publisher.js
+++ b/src/services/mhs/mhs-queue-test-queue-publisher.js
@@ -1,6 +1,6 @@
-import { connectToQueue } from '../../config/queue';
+import { v4 as uuid } from 'uuid';
 import config from '../../config';
-import uuid from 'uuid/v4';
+import { connectToQueue } from '../../config/queue';
 
 const putMessageOnQueue = (client, message) => {
   const transaction = client.begin();

--- a/src/services/parser/__tests__/extract-conversation-id.test.js
+++ b/src/services/parser/__tests__/extract-conversation-id.test.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import { extractConversationId } from '../soap-parser/extract-conversation-id';
 
 describe('extractConversationId', () => {

--- a/src/services/parser/__tests__/extract-message-id.test.js
+++ b/src/services/parser/__tests__/extract-message-id.test.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import { extractMessageId } from '../soap-parser/extract-message-id';
 
 describe('extractMessageId', () => {

--- a/src/templates/__tests__/ehr-request-template.test.js
+++ b/src/templates/__tests__/ehr-request-template.test.js
@@ -1,5 +1,5 @@
 const generateEhrRequestQuery = require('../ehr-request-template');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 const dateFormat = require('dateformat');
 const testData = require('./testData.json');
 

--- a/src/templates/__tests__/generate-update-ods-request.test.js
+++ b/src/templates/__tests__/generate-update-ods-request.test.js
@@ -1,6 +1,6 @@
 const generateUpdateOdsRequest = require('../generate-update-ods-request');
-const uuid = require('uuid/v4');
 import dateFormat from 'dateformat';
+const { v4: uuid } = require('uuid');
 const testData = require('./testData.json');
 
 describe('generateUpdateOdsRequest', () => {

--- a/utils/generate-messages.js
+++ b/utils/generate-messages.js
@@ -1,4 +1,4 @@
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 const dateFormat = require('dateformat');
 const generateEhrRequestQuery = require('../src/templates/ehr-request-template');
 const generateUpdatePdsRequest = require('../src/templates/generate-update-ods-request');


### PR DESCRIPTION
- And adds uuid as an automatically mocked module by default

Should remove this error:

<img width="677" alt="Screenshot 2020-03-16 at 12 15 52" src="https://user-images.githubusercontent.com/25727036/76758464-a1ba3a80-6781-11ea-81db-0304d00e3799.png">

And see[ linked article](https://github.com/uuidjs/uuid#deep-requires-now-deprecated)